### PR TITLE
Specify parent HTMLElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Both the parent window and iFrame must load COMB.
 <script type="text/javascript" src="./holo_hosting_comb.js"></script>
 <script type="text/javascript">
 (async () => {
-    const child = await comb.connect( url, 5000, signal => console.log('comb got signal', signal) );
+    const child = await comb.connect( url, document.body, 5000, signal => console.log('comb got signal', signal) );
 
     await child.set("development_mode", true );
     await child.set("welcome_greeting", "Hello" );

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,8 @@ const COMB = {
    * @function connect
    *
    * @param {string} url		- URL that is used as 'src' for the iframe
-   *
+   * @param {HTMLElement} container	  - Parent HTMLElement to insert the iframe into
+
    * @return {ChildAPI} Connection to child frame
    *
    * @example
@@ -74,10 +75,11 @@ const COMB = {
    */
   async connect (
     url: string,
+    container: HTMLElement,
     timeout: number,
     signalCb: (signal: unknown) => void
   ): Promise<ChildAPI> {
-    const child = new ChildAPI(url, timeout, signalCb)
+    const child = new ChildAPI(url, container, timeout, signalCb)
     await child.connect()
     return child
   },
@@ -146,7 +148,7 @@ class ChildAPI {
    * await child.set("mode", mode );
    * let response = await child.run("signIn");
    */
-  constructor (url, timeout = 5_000, signalCb) {
+  constructor (url, container: HTMLElement = document.body, timeout = 5_000, signalCb) {
     this.url = url
     this.msg_count = 0
     this.responses = {}
@@ -158,7 +160,7 @@ class ChildAPI {
     this.handshake = async_with_timeout(async () => {
       // log.info("Init Postmate handshake");
       const handshake = new Postmate({
-        container: document.body,
+        container,
         url: this.url,
         classListArray: [this.class_name]
       })

--- a/tests/integration/test_comb.js
+++ b/tests/integration/test_comb.js
@@ -219,7 +219,7 @@ describe('Testing COMB', function () {
     })
 
     const answer = await page.evaluate(async function (chap_url) {
-      window.child = await COMB.connect(chap_url, 5000, window.signalCb)
+      window.child = await COMB.connect(chap_url, document.body, 5000, window.signalCb)
       await child.run('test_signal', new Uint8Array([1, 4]))
       const signalEmitted = window.signalCbCalledWith
       // Puppeteer can't pass through Uint8Arrays
@@ -235,7 +235,7 @@ describe('Testing COMB', function () {
   it('should timeout because of wrong frame URL', async function () {
     const result = await page.evaluate(async function () {
       try {
-        await COMB.connect('http://localhost:55555', 500)
+        await COMB.connect('http://localhost:55555', document.body, 500)
       } catch (err) {
         console.log('Caught expected error:', err)
         return err.toString()
@@ -251,7 +251,7 @@ describe('Testing COMB', function () {
 
     const result = await page.evaluate(async function (frame_url) {
       try {
-        await COMB.connect(frame_url, 500)
+        await COMB.connect(frame_url, document.body, 500)
       } catch (err) {
         console.log('Caught expected error:', err)
         return err.toString()


### PR DESCRIPTION
Adds an option to COMB.connect to specify the parent HTMLElement to insert the iframe into, defaulting to document.body.

The use case is that I don't want the login iframe to takeover the entire screen, I want to contain it within an element in my existing UI.

This has not been tested -- the tests seem to fail within a few seconds (apparently before the test environment setup is complete). Is there a known way to run the test suite? @robbiecarlton 